### PR TITLE
Fix: allowNoRating being ignored in snippet navigation validation

### DIFF
--- a/ui/src/components/SnippetRatingEditor/index.tsx
+++ b/ui/src/components/SnippetRatingEditor/index.tsx
@@ -94,7 +94,7 @@ export default function SnippetRatingEditor({
       if (!editable)
         return;
       const ratingValue = snippets[selected].rate?.value;
-      if (ratingValue === undefined || ratingValue === 0) {
+      if (!allowNoRating && (ratingValue === undefined || ratingValue === 0)) {
         dispatch(pushNotification({
           message: 'Rating is required',
           variant: 'error',
@@ -123,7 +123,8 @@ export default function SnippetRatingEditor({
     },
     [
       snippets, selected, editable, showQuestions,
-      setHiddenQuestion, dispatch, onRatingSubmit,
+      , allowNoRating, setHiddenQuestion, dispatch,
+      onRatingSubmit,
     ]
   );
 


### PR DESCRIPTION
When allowNoRating is enabled in the dataset configuration, users are still blocked from proceeding to the next snippet without providing a star rating. The handleRatingSubmit function unconditionally checks for ratingValue === undefined || ratingValue === 0, ignoring the allowNoRating prop.